### PR TITLE
fix(Cargo.toml): enable native-tls for tungstenite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "sha-1",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.73"
 structopt = "0.3.25"
 tokio = { version = "1.15.0", features = ["full"] }
-tungstenite = "0.16.0"
+tungstenite = { version = "0.16.0", features = ["native-tls"] }
 twitch-irc = "3.0.1"
 url = "2.2.2"


### PR DESCRIPTION
This enables `native-tls` support for the `wss` connection to Quirk.